### PR TITLE
Add toggle to autopost preferred username

### DIFF
--- a/src/main/kotlin/io/curity/identityserver/plugin/username/authentication/RequestModel.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/username/authentication/RequestModel.kt
@@ -1,17 +1,27 @@
 package io.curity.identityserver.plugin.username.authentication
 
 import org.hibernate.validator.constraints.NotBlank
+import se.curity.identityserver.sdk.service.OriginalQueryExtractor
+import se.curity.identityserver.sdk.service.UserPreferenceManager
 import se.curity.identityserver.sdk.web.Request
 import javax.validation.Valid
 
-class RequestModel(request: Request) {
+class RequestModel(request: Request, userPreferenceManager: UserPreferenceManager)
+{
     @Valid
-    val postRequestModel: Post? = if (request.isPostRequest) Post(request)
-    else
-        null
+    val postRequestModel: Post? = if (request.isPostRequest) Post(request) else null
+
+    @Valid
+    val getRequestModel: Get? = if (request.isGetRequest) Get(userPreferenceManager) else null
 }
 
-class Post(request: Request) {
+class Post(request: Request)
+{
     @NotBlank(message = "validation.error.username.required")
     val username: String = request.getFormParameterValueOrError("username")
+}
+
+class Get(userPreferenceManager: UserPreferenceManager)
+{
+    val preferredUserName: String? = userPreferenceManager.username
 }

--- a/src/main/kotlin/io/curity/identityserver/plugin/username/config/UsernameAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/username/config/UsernameAuthenticatorPluginConfig.kt
@@ -1,8 +1,20 @@
 package io.curity.identityserver.plugin.username.config;
 
 import se.curity.identityserver.sdk.config.Configuration
+import se.curity.identityserver.sdk.config.annotation.DefaultBoolean
+import se.curity.identityserver.sdk.config.annotation.Description
+import se.curity.identityserver.sdk.service.ExceptionFactory
+import se.curity.identityserver.sdk.service.OriginalQueryExtractor
 import se.curity.identityserver.sdk.service.UserPreferenceManager
 
-interface UsernameAuthenticatorPluginConfig : Configuration {
+interface UsernameAuthenticatorPluginConfig : Configuration
+{
     val userPreferencesManager: UserPreferenceManager
+    val exceptionFactory : ExceptionFactory
+
+    @Description("If there is a preferred username in the username cookie, pass it on without prompting the user. " +
+            "This cookie value can reside from a previous succesful authentication, or the client sending a " +
+            "`login_hint`.")
+    @DefaultBoolean(false)
+    fun autoSubmitPreferredUserName(): Boolean
 }


### PR DESCRIPTION
Add a toggle that can allow the authenticator to autoselect the username from the cookie as the username. This is useful when you want to allow the client to select the username to authenticate using the `login_hint` parameter. 