### PR TITLE
Render an error template when an authentication exception occurs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.curity.identityserver.plugin</groupId>
     <artifactId>identityserver.plugins.authenticators.username</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>Curity Username Authenticator</name>

--- a/src/main/kotlin/io/curity/identityserver/plugin/username/authentication/UsernameAuthenticatorRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/username/authentication/UsernameAuthenticatorRequestHandler.kt
@@ -74,13 +74,6 @@ class UsernameAuthenticatorRequestHandler(config: UsernameAuthenticatorPluginCon
 
     override fun preProcess(request: Request, response: Response): RequestModel
     {
-        if (request.isGetRequest)
-        {
-            // GET request
-            response.putViewData("username", userPreferencesManager.username,
-                    Response.ResponseModelScope.NOT_FAILURE)
-        }
-
         // set the template and model for responses on the NOT_FAILURE scope
         response.setResponseModel(templateResponseModel(
             singletonMap("username", userPreferencesManager.username as Any?),

--- a/src/main/kotlin/io/curity/identityserver/plugin/username/authentication/UsernameAuthenticatorRequestHandler.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/username/authentication/UsernameAuthenticatorRequestHandler.kt
@@ -25,9 +25,11 @@ import se.curity.identityserver.sdk.attribute.SubjectAttributes
 import se.curity.identityserver.sdk.authentication.AuthenticationResult
 import se.curity.identityserver.sdk.authentication.AuthenticatorRequestHandler
 import se.curity.identityserver.sdk.errors.ErrorCode
+import se.curity.identityserver.sdk.http.HttpStatus
 import se.curity.identityserver.sdk.web.Request
 import se.curity.identityserver.sdk.web.Response
 import se.curity.identityserver.sdk.web.ResponseModel.templateResponseModel
+import java.util.Collections.singletonMap
 import java.util.Date
 import java.util.Optional
 
@@ -79,9 +81,14 @@ class UsernameAuthenticatorRequestHandler(config: UsernameAuthenticatorPluginCon
                     Response.ResponseModelScope.NOT_FAILURE)
         }
 
+        // set the template and model for responses on the NOT_FAILURE scope
+        response.setResponseModel(templateResponseModel(
+            singletonMap("username", userPreferencesManager.username as Any?),
+            templateName), Response.ResponseModelScope.NOT_FAILURE)
+
         // on request validation failure, we should use the same template as for NOT_FAILURE
-        response.setResponseModel(templateResponseModel(emptyMap<String, Any>(),
-                templateName), Response.ResponseModelScope.ANY)
+        response.setResponseModel(templateResponseModel(emptyMap(),
+            templateName), HttpStatus.BAD_REQUEST)
 
         return RequestModel(request, userPreferencesManager)
     }


### PR DESCRIPTION
Set ResponseModel template to render login view when authentication request can be handled or fails because of request validation. Otherwise, let default error templates being applied at higher level especially in case of authentication failure.
